### PR TITLE
Fix inproprer handle of double quote

### DIFF
--- a/src/pwnrm/shell/shares.py
+++ b/src/pwnrm/shell/shares.py
@@ -20,7 +20,7 @@ def get_shares_ps(quick: bool = False, targets: Optional[List[str]] = None) -> s
 
     if targets:
         # [NICHE AUDIT 2 FIX] Embed as PS string array with proper single-quote escaping: @('host1','host2')
-        target_str = ",".join(f"'{t.strip().replace("'", "''")}'" for t in targets if t.strip())
+        target_str = ",".join("'" + t.strip().replace("'", "''") + "'" for t in targets if t.strip())
         ps = ps.replace("'__TARGETS__'", target_str)
     else:
         # Replace the entire @('__TARGETS__') expression so the result is @()


### PR DESCRIPTION
Hi,

PR that correct one error I occur when I launch pwnrm : 

```
[Sep 03, 2026 - 07:28:58 (CEST)] exegol-test /workspace # pwnrm --help
Traceback (most recent call last):
  File "/root/.local/bin/pwnrm", line 3, in <module>
    from pwnrm.cli import main
  File "/root/.local/share/pipx/venvs/pwnrm/lib/python3.11/site-packages/pwnrm/__init__.py", line 19, in <module>
    from .shell import PwnShell
  File "/root/.local/share/pipx/venvs/pwnrm/lib/python3.11/site-packages/pwnrm/shell/__init__.py", line 5, in <module>
    from .pwnshell import PwnShell
  File "/root/.local/share/pipx/venvs/pwnrm/lib/python3.11/site-packages/pwnrm/shell/pwnshell.py", line 39, in <module>
    from .shares    import get_shares_ps
  File "/root/.local/share/pipx/venvs/pwnrm/lib/python3.11/site-packages/pwnrm/shell/shares.py", line 23
    target_str = ",".join(f"'{t.strip().replace("'", "''")}'" for t in targets if t.strip())
                                                            ^
SyntaxError: unterminated string literal (detected at line 23)
```

And with the fix : 

```
[Sep 03, 2026 - 07:43:23 (CEST)] exegol-test /workspace # pwnrm --help


██████╗ ██╗    ██╗███╗   ██╗██████╗ ███╗   ███╗
██╔══██╗██║    ██║████╗  ██║██╔══██╗████╗ ████║
██████╔╝██║ █╗ ██║██╔██╗ ██║██████╔╝██╔████╔██║
██╔═══╝ ██║███╗██║██║╚██╗██║██╔══██╗██║╚██╔╝██║
██║     ╚███╔███╔╝██║ ╚████║██║  ██║██║ ╚═╝ ██║
╚═╝      ╚══╝╚══╝ ╚═╝  ╚═══╝╚═╝  ╚═╝╚═╝     ╚═╝
    Advanced WinRM / AD Post-Exploitation Platform  v2.1.0 (2026+ TTPs)
  github.com/uziii2208/PwnRM  ·  For authorized engagements only.

usage: pwnrm [-h] [-u USERNAME] [-p PASSWORD] [-d DOMAIN] [-H NTHASH] [-k] [--ccache FILE] [--pfx FILE] [--pfx-pass PASS] [--credssp] [--port PORT] [--ssl]
             [--no-ssl-verify] [--timeout TIMEOUT] [-X CMD] [--replay LOGFILE] [--ts] [--debug]
             target

PwnRM v2.1.0 — Advanced WinRM / AD Post-Exploitation Platform (2026+ TTPs)
```

Thanks :)